### PR TITLE
KoinによるDI導入（Repository / UseCase / ViewModel）

### DIFF
--- a/app-wasm/build.gradle.kts
+++ b/app-wasm/build.gradle.kts
@@ -34,6 +34,9 @@ kotlin {
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
             implementation(projects.feature.clock)
+            implementation(libs.koin.core)
+            implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
         }
     }
 }

--- a/app-wasm/build.gradle.kts
+++ b/app-wasm/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
+            implementation(projects.core.domain)
             implementation(projects.feature.clock)
             implementation(libs.koin.core)
             implementation(libs.koin.compose)

--- a/app-wasm/src/wasmJsMain/kotlin/io/github/kabos/bus/main.kt
+++ b/app-wasm/src/wasmJsMain/kotlin/io/github/kabos/bus/main.kt
@@ -3,9 +3,12 @@ package io.github.kabos.bus
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
+import io.github.kabos.bus.core.domain.di.domainModule
 import io.github.kabos.bus.feature.clock.BusTheme
 import io.github.kabos.bus.feature.clock.ClockScreen
+import io.github.kabos.bus.feature.clock.di.clockModule
 import kotlinx.browser.document
+import org.koin.compose.KoinApplication
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
@@ -16,7 +19,11 @@ fun main() {
 
 @Composable
 private fun App() {
-    BusTheme {
-        ClockScreen()
+    KoinApplication(application = {
+        modules(domainModule, clockModule)
+    }) {
+        BusTheme {
+            ClockScreen()
+        }
     }
 }

--- a/app-wearos/build.gradle.kts
+++ b/app-wearos/build.gradle.kts
@@ -55,4 +55,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.wearos)
     implementation(libs.bundles.wearos.debug)
+    implementation(libs.koin.android)
+    implementation(libs.koin.compose)
+    implementation(libs.koin.compose.viewmodel)
 }

--- a/app-wearos/src/main/AndroidManifest.xml
+++ b/app-wearos/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-feature android:name="android.hardware.type.watch" />
 
     <application
+        android:name=".BusApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/app-wearos/src/main/java/io/github/kabos/bus/BusApplication.kt
+++ b/app-wearos/src/main/java/io/github/kabos/bus/BusApplication.kt
@@ -1,0 +1,20 @@
+package io.github.kabos.bus
+
+import android.app.Application
+import io.github.kabos.bus.core.domain.di.domainModule
+import io.github.kabos.bus.di.wearosModule
+import io.github.kabos.bus.feature.clock.di.clockModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.startKoin
+
+class BusApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidLogger()
+            androidContext(this@BusApplication)
+            modules(domainModule, clockModule, wearosModule)
+        }
+    }
+}

--- a/app-wearos/src/main/java/io/github/kabos/bus/di/WearosModule.kt
+++ b/app-wearos/src/main/java/io/github/kabos/bus/di/WearosModule.kt
@@ -1,0 +1,9 @@
+package io.github.kabos.bus.di
+
+import io.github.kabos.bus.presentation.TimelineViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+val wearosModule = module {
+    viewModelOf(::TimelineViewModel)
+}

--- a/app-wearos/src/main/java/io/github/kabos/bus/presentation/MainActivity.kt
+++ b/app-wearos/src/main/java/io/github/kabos/bus/presentation/MainActivity.kt
@@ -3,12 +3,12 @@ package io.github.kabos.bus.presentation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
+import org.koin.androidx.viewmodel.ext.android.viewModel
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import io.github.kabos.bus.feature.clock.BusTheme
 
 class MainActivity : ComponentActivity() {
-    private val viewModel: TimelineViewModel by viewModels()
+    private val viewModel: TimelineViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()

--- a/app-wearos/src/main/java/io/github/kabos/bus/presentation/TimelineViewModel.kt
+++ b/app-wearos/src/main/java/io/github/kabos/bus/presentation/TimelineViewModel.kt
@@ -6,7 +6,6 @@ import io.github.kabos.bus.core.domain.GetBusDepartureTimeUseCase
 import io.github.kabos.bus.core.domain.extension.now
 import io.github.kabos.bus.core.domain.mvi.MVI
 import io.github.kabos.bus.core.domain.mvi.mviDelegate
-import io.github.kabos.bus.core.domain.repository.DefaultTimetableRepository
 import io.github.kabos.bus.core.model.DayType
 import io.github.kabos.bus.core.model.StationName
 import io.github.kabos.bus.core.model.TimetableCell
@@ -22,11 +21,10 @@ import kotlinx.datetime.LocalTime
 // ベタ打ちであんまり良くない
 private val InitState = listOf(Init, Init)
 
-class TimelineViewModel :
-    ViewModel(),
+class TimelineViewModel(
+    private val useCase: GetBusDepartureTimeUseCase,
+) : ViewModel(),
     MVI<List<UiState>, UiAction, SideEffect> by mviDelegate(initialUiState = InitState) {
-    private val repository = DefaultTimetableRepository()
-    private val useCase = GetBusDepartureTimeUseCase(repository)
 
     override fun onAction(uiAction: UiAction) {
         viewModelScope.launch {

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlin.result)
+            implementation(libs.koin.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/core/domain/src/commonMain/kotlin/io/github/kabos/bus/core/domain/di/DomainModule.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/kabos/bus/core/domain/di/DomainModule.kt
@@ -1,0 +1,12 @@
+package io.github.kabos.bus.core.domain.di
+
+import io.github.kabos.bus.core.domain.GetBusDepartureTimeUseCase
+import io.github.kabos.bus.core.domain.repository.DefaultTimetableRepository
+import io.github.kabos.bus.core.domain.repository.TimetableRepository
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.module
+
+val domainModule = module {
+    single<TimetableRepository> { DefaultTimetableRepository() }
+    factoryOf(::GetBusDepartureTimeUseCase)
+}

--- a/feature/clock/build.gradle.kts
+++ b/feature/clock/build.gradle.kts
@@ -23,6 +23,9 @@ kotlin {
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
             implementation(libs.lifecycle.viewmodel.compose)
+            implementation(libs.koin.core)
+            implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/feature/clock/src/commonMain/kotlin/io/github/kabos/bus/feature/clock/ClockScreen.kt
+++ b/feature/clock/src/commonMain/kotlin/io/github/kabos/bus/feature/clock/ClockScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import org.koin.compose.viewmodel.koinViewModel
 import io.github.kabos.bus.core.model.StationName
 import io.github.kabos.bus.feature.clock.ClockContract.SideEffect
 import io.github.kabos.bus.feature.clock.ClockContract.UiAction
@@ -37,7 +37,7 @@ import kotlinx.coroutines.launch
 // https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-viewmodel.html#using-viewmodel-in-common-code
 @Composable
 fun ClockScreen(
-    viewModel: ClockViewModel = viewModel { ClockViewModel() },
+    viewModel: ClockViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val sideEffect = viewModel.sideEffect

--- a/feature/clock/src/commonMain/kotlin/io/github/kabos/bus/feature/clock/ClockViewModel.kt
+++ b/feature/clock/src/commonMain/kotlin/io/github/kabos/bus/feature/clock/ClockViewModel.kt
@@ -10,7 +10,7 @@ import io.github.kabos.bus.core.domain.GetBusDepartureTimeUseCase
 import io.github.kabos.bus.core.domain.extension.now
 import io.github.kabos.bus.core.domain.mvi.MVI
 import io.github.kabos.bus.core.domain.mvi.mviDelegate
-import io.github.kabos.bus.core.domain.repository.DefaultTimetableRepository
+import io.github.kabos.bus.core.domain.repository.TimetableRepository
 import io.github.kabos.bus.core.model.BusRouteName
 import io.github.kabos.bus.core.model.DayType
 import io.github.kabos.bus.core.model.StationName
@@ -57,12 +57,12 @@ interface ClockContract {
     }
 }
 
-class ClockViewModel : ViewModel(),
+class ClockViewModel(
+    private val repository: TimetableRepository,
+    private val useCase: GetBusDepartureTimeUseCase,
+) : ViewModel(),
     MVI<UiState, UiAction, SideEffect> by mviDelegate(initialUiState = Init) {
 
-    // todo DI
-    private val repository = DefaultTimetableRepository()
-    private val useCase = GetBusDepartureTimeUseCase(repository)
     private val stationNames = listOf(StationName.takinoi, StationName.tsudanuma)
 
     private var selectedStation = stationNames.first()

--- a/feature/clock/src/commonMain/kotlin/io/github/kabos/bus/feature/clock/di/ClockModule.kt
+++ b/feature/clock/src/commonMain/kotlin/io/github/kabos/bus/feature/clock/di/ClockModule.kt
@@ -1,0 +1,9 @@
+package io.github.kabos.bus.feature.clock.di
+
+import io.github.kabos.bus.feature.clock.ClockViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+val clockModule = module {
+    viewModelOf(::ClockViewModel)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ wearCompose = "1.4.0"
 coreSplashscreen = "1.0.1"
 wearToolingPreview = "1.0.0"
 jetbrainsKotlinJvm = "2.0.10"
+koin = "4.0.0"
 
 [libraries]
 androidGradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -28,6 +29,10 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 kotlinGradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 
 # wearOS
 play-services-wearable = { group = "com.google.android.gms", name = "play-services-wearable", version.ref = "playServicesWearable" }


### PR DESCRIPTION
## Summary

- Koin 4.0.0 を使って Repository・UseCase・ViewModel の依存関係をコンストラクタインジェクションに移行
- `ClockViewModel` / `TimelineViewModel` のハードコード依存（`// todo DI`）を解消
- Android（WearOS）と WASM でそれぞれ適切な方法で Koin を起動

## 変更内容

### 新規ファイル
| ファイル | 役割 |
|---|---|
| `core/domain/.../di/DomainModule.kt` | `TimetableRepository` → `DefaultTimetableRepository` バインディング、`GetBusDepartureTimeUseCase` 提供 |
| `feature/clock/.../di/ClockModule.kt` | `ClockViewModel` の登録 |
| `app-wearos/.../di/WearosModule.kt` | `TimelineViewModel` の登録 |
| `app-wearos/.../BusApplication.kt` | Android の `startKoin` 起動（`domainModule` + `clockModule` + `wearosModule`） |

### 主な変更
- `ClockViewModel` / `TimelineViewModel`: コンストラクタで `TimetableRepository` / `GetBusDepartureTimeUseCase` を受け取るよう変更
- `ClockScreen`: `viewModel { ClockViewModel() }` → `koinViewModel()`
- `MainActivity`: `by viewModels()` → Koin の `by viewModel()`
- `AndroidManifest.xml`: `android:name=".BusApplication"` を追加
- `app-wasm/main.kt`: `App()` を `KoinApplication { }` でラップ（WASM は Application クラス不要）
- `app-wasm/build.gradle.kts`: `projects.core.domain` を明示的に追加

## Test plan

- [ ] `./gradlew :app-wearos:assembleDebug` でビルド成功を確認
- [ ] `./gradlew :app-wasm:wasmJsBrowserDistribution` でビルド成功を確認
- [ ] `./gradlew test` でテスト通過を確認
- [ ] `./gradlew detekt` で新規違反がないことを確認
- [ ] WearOS 実機 / エミュレータでバス時刻表が正常表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)